### PR TITLE
Fix saving configuration form

### DIFF
--- a/Koha/Plugin/Carrousel/configure.tt
+++ b/Koha/Plugin/Carrousel/configure.tt
@@ -370,7 +370,7 @@ $("#doc3 form").submit(function (){
     var form = $("form").serializeArray();
 
     var enablings = [];
-    $("tbody tr").each(function (){
+    $("tbody:first tr").each(function (){
         var carrousel = $(this);
         var id = carrousel.attr("id").split("-");
         var data = {


### PR DESCRIPTION
This fixes an issue where if you submit the configuration form, a console error 'Cannot read properties of undefined' is thrown and no data is saved.